### PR TITLE
cleanup nintendo_nas_server and implement stub /pr handling

### DIFF
--- a/gamespy/gs_database.py
+++ b/gamespy/gs_database.py
@@ -1,6 +1,7 @@
 import sqlite3
 import hashlib
 import itertools
+import json
 import time
 import logging
 
@@ -381,7 +382,7 @@ class GamespyDatabase(object):
         if r == None:
             return None
         else:
-            return r["data"]
+            return json.loads(r["data"])
 
     def generate_authtoken(self, userid, data):
         # Since the auth token passed back to the game will be random, we can make it small enough that there
@@ -403,6 +404,7 @@ class GamespyDatabase(object):
 
         c.execute(q, [userid])
         r = self.get_dict(c.fetchone())
+        data = json.dumps(data)
 
         if r == None: # no row, add it
             q = "INSERT INTO nas_logins VALUES (?, ?, ?)"

--- a/gamespy/gs_utility.py
+++ b/gamespy/gs_utility.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import json
 import time
 
 import other.utils as utils
@@ -67,14 +66,7 @@ def prepare_rc4_base64(_key, _data):
 
 # get the login data from nas.nintendowifi.net/ac from an authtoken
 def parse_authtoken(authtoken, db):
-    messages = {}
-    nas_data = db.get_nas_login(authtoken)
-
-    if nas_data == None:
-       return None
-
-    return json.loads(nas_data)
-
+    return db.get_nas_login(authtoken)
 
 def generate_response(challenge, ac_challenge, secretkey, authtoken):
     md5 = hashlib.md5()


### PR DESCRIPTION
Just some cleanups.

nas.nintendowifi.net/pr is supposed to accept a string and return the number of "banned" words used in the string but for now we just return 0 ever time.

Also, technically parse_authtoken() could be removed since it's just a stub for the db function but I left it in in case the way getting the authtoken data changes in the future.
