### PR TITLE
Just use a for loop instead of creating tons of wrapper functions

### DIFF
--- a/master_server.py
+++ b/master_server.py
@@ -13,78 +13,24 @@ import gamespy.gs_database as gs_database
 
 import threading
 
-def start_backend_server():
-    backend_server = GameSpyBackendServer()
-    backend_server.start()
-
-def start_qr_server():
-    qr_server = GameSpyQRServer()
-    qr_server.start()
-
-def start_profile_server():
-    profile_server = GameSpyProfileServer()
-    profile_server.start()
-
-def start_player_search_server():
-    player_search_server = GameSpyPlayerSearchServer()
-    player_search_server.start()
-
-def start_gamestats_server():
-    gamestats_server = GameSpyGamestatsServer()
-    gamestats_server.start()
-
-def start_server_browser_server():
-    server_browser_server = GameSpyServerBrowserServer()
-    server_browser_server.start()
-
-def start_natneg_server():
-    natneg_server = GameSpyNatNegServer()
-    natneg_server.start()
-
-def start_nas_server():
-    nas_server = NasServer()
-    nas_server.start()
-
-def start_stats_server():
-    stats_server = InternalStatsServer()
-    stats_server.start()
-    
-def start_storage_server():
-    storage_server = StorageServer()
-    storage_server.start()
 
 if __name__ == "__main__":
     # Let database initialize before starting any servers.
     # This fixes any conflicts where two servers find an uninitialized database at the same time and both try to
     # initialize it.
     database = gs_database.GamespyDatabase()
-
-    backend_server_thread = threading.Thread(target=start_backend_server)
-    backend_server_thread.start()
-
-    qr_server_thread = threading.Thread(target=start_qr_server)
-    qr_server_thread.start()
-
-    profile_server_thread = threading.Thread(target=start_profile_server)
-    profile_server_thread.start()
-
-    player_search_server_thread = threading.Thread(target=start_player_search_server)
-    player_search_server_thread.start()
-
-    player_gamestats_thread = threading.Thread(target=start_gamestats_server)
-    player_gamestats_thread.start()
-
-    #server_browser_server_thread = threading.Thread(target=start_server_browser_server)
-    #server_browser_server_thread.start()
-
-    natneg_server_thread = threading.Thread(target=start_natneg_server)
-    natneg_server_thread.start()
-
-    nas_server_thread = threading.Thread(target=start_nas_server)
-    nas_server_thread.start()
-
-#    stats_server_thread = threading.Thread(target=start_stats_server)
-#    stats_server_thread.start()
-
-    storage_server_thread = threading.Thread(target=start_storage_server)
-    storage_server_thread.start()
+    
+    servers = [
+        GameSpyBackendServer,
+        GameSpyQRServer,
+        GameSpyProfileServer,
+        GameSpyPlayerSearchServer,
+        GameSpyGamestatsServer,
+        #GameSpyServerBrowserServer,
+        GameSpyNatNegServer,
+        NasServer,
+        #InternalStatsServer,
+        StorageServer,
+    ]
+    for server in servers:
+        threading.Thread(target=lambda:server().start()).start()

--- a/master_server.py
+++ b/master_server.py
@@ -33,4 +33,4 @@ if __name__ == "__main__":
         StorageServer,
     ]
     for server in servers:
-        threading.Thread(target=lambda:server().start()).start()
+        threading.Thread(target=server().start).start()


### PR DESCRIPTION
There's really no need to create wrappers like that, especially when even the wrappers could have been made simpler by introducing a simple function:

``` python
def start_server(server):
    def _start_server_():
        srv = server()
        srv.start()
    return _start_server_

start_backend_server = start_server(GameSpyBackendServer)
# ...
```

From there, we know that we can just combine the assignment and the call to .start():

``` python
def start_server(server):
    def _start_server_():
        server().start()
    return _start_server_
```

This is a good use case for a lambda function:

``` python
def start_server(server):
    return lambda:server().start()
```

which can be simplified as in my second commit:

``` python
def start_server(server):
    return server().start
```
