### PR TITLE
Support PAL/NTSC or international or something...

### DIFF
--- a/gamespy_qr_server.py
+++ b/gamespy_qr_server.py
@@ -324,6 +324,11 @@ class GameSpyQRServer(object):
                 be = self.sessions[session_id].console != 0
                 k['publicip'] = str(utils.get_ip(bytearray([int(x) for x in address[0].split('.')]), 0, be))
 
+            if 'publicport' in k and 'localport' in k and k['publicport'] != k['localport']:
+                self.log(logging.DEBUG, address, "publicport %s doesn't match localport %s, so changing publicport to %s..." \
+                    % (k['publicport'], k['localport'], str(address[1])))
+                k['publicport'] = str(address[1])
+
             if "statechanged" in k:
                 if k['statechanged'] == "2": # Close server
                      self.server_manager.delete_server(k['gamename'] , session_id)

--- a/other/utils.py
+++ b/other/utils.py
@@ -75,6 +75,9 @@ def base32_encode(num, reverse=True):
         encoded += alpha[num & 0x1f]
         num = num >> 5
 
+    while len(encoded) < 9:
+      encoded += "0"
+
     if reverse == True:
         encoded = encoded[::-1]  # Reverse string
 


### PR DESCRIPTION
I'm running the altwfc code on a cloud server. http://altwfc.udon.dontrush.me/

A Tatsunok-vsCapcom(TvC) player in Croatia, using the PAL version the game, but console set to UK,
was never able to play other people in California(or... anywhere) until these changes were made. This is
probably how the official servers worked. I suspect these changes will help some other games work a little better too.

Big thanks to <code>http://www.gamefaqs.com/users/Dying_2_Liv3</code> who had to be up at night in his timezone to debug with me.

2 problems
- First, his game/console gave altwfc a userid "0932730654601". That leading zero gets dropped by the int() conversion before the call to base32_encode and thus the string returned by this function was one char too short. Because the uniquenick is created by concat'ing this string and the gsbrcd, the PAL TvC player was getting a uniquenick that was 19 chars when everyone else got 20. I prepend the base32 encoded string with "0"s until it is 9 chars long. This seems to be the correct solution because doing this does not effect the result of the decoding function and notice in this screenshot <code>http://i.imgur.com/maVe0tK.png</code> , that "aim" value gets the "0" prepended even though the uniquenick was missing it. This implies that there is code in the game that also prepends.
- Second, for some reason the publicport is not the same as the localport in the heartbeat packets. This TvC player is the only one that has this difference. <code>http://i.imgur.com/NNigdNO.png</code> The encrypted list of servers returned by gamespy_backend_server.py seems to end up using the localport. The very first search the game does is a search for itself, presumably to determine what the publicip and publicport is from the point of view of the outside world. By using the localport instead of the publicport in this list, the game appears to get confused and try again. 8-10 seconds later the game sets dwc_suspend=1 in the heartbeats and keeps doing searches only for itself over & over. Perhaps the correct fix is to make sure the backendServer uses the publicport when available instead of the publicport. After looking at that code for awhile I simply couldn't figure it out and maybe it's doing the right thing incase people are playing against each other locally. I concluded that maybe the dwc_suspend thing is being used for this situation somehow so I added code to detect when this happens and manually set the publicport to the value the heartbeat was received from.
