### PR TITLE
Backend: Fix KeyError during NATNEG init

### DIFF
--- a/gamespy_backend_server.py
+++ b/gamespy_backend_server.py
@@ -547,6 +547,9 @@ class GameSpyBackendServer(object):
         localip_int_be = localaddr[3]
 
         def find_server(gameid):
+            if gameid not in self.server_list:
+                return None
+
             best_match = None
 
             for server in self.server_list[gameid]:


### PR DESCRIPTION
This PR fixes an exception during NAT negotiation in Monster Hunter 3.

Ready to be reviewed & merged.